### PR TITLE
Adds support for validating multiple CSV

### DIFF
--- a/bin/csv-test
+++ b/bin/csv-test
@@ -2,8 +2,17 @@
 
 var fs = require('fs'),
     path = require('path'),
-    args = process.argv.slice(2),
-    config = fs.readFileSync(path.resolve(process.cwd(), args[0]), 'utf8'),
+    args = process.argv.slice(2);
+
+    // If a wildcard is not enclosed in a parantheses it will pass wildcard
+    // results instead of the wildcard.
+    if (/\.csv$/i.test(args[2])) {
+      console.log("Invalid syntax. If you are passing on a wildcard make sure it is enclosed in parantheses.");
+      process.exit(1);
+    }
+
+var config = fs.readFileSync(path.resolve(process.cwd(), args[0]), 'utf8'),
     validators = args[2] && require(path.resolve(process.cwd(), args[2]));
+
 
 require('..')(config, args[1], validators);

--- a/bin/csv-test
+++ b/bin/csv-test
@@ -4,7 +4,6 @@ var fs = require('fs'),
     path = require('path'),
     args = process.argv.slice(2),
     config = fs.readFileSync(path.resolve(process.cwd(), args[0]), 'utf8'),
-    stream = fs.createReadStream(path.resolve(process.cwd(), args[1]), 'utf8'),
     validators = args[2] && require(path.resolve(process.cwd(), args[2]));
 
-require('..')(config, stream, validators);
+    require('..')(config, args[1], validators);

--- a/bin/csv-test
+++ b/bin/csv-test
@@ -6,4 +6,4 @@ var fs = require('fs'),
     config = fs.readFileSync(path.resolve(process.cwd(), args[0]), 'utf8'),
     validators = args[2] && require(path.resolve(process.cwd(), args[2]));
 
-    require('..')(config, args[1], validators);
+require('..')(config, args[1], validators);

--- a/index.js
+++ b/index.js
@@ -1,85 +1,111 @@
 var _ = require('lodash'),
     chalk = require('chalk'),
+    fs = require('fs'),
+    glob = require("glob"),
+    path = require('path'),
     yaml = require('js-yaml'),
     parse = require('csv-parse'),
     validator = require('validator'),
     transform = require('stream-transform');
 
-module.exports = function(yml, stream, validators) {
+module.exports = function(yml, arg, validators) {
+  var indexCount = [];
+  var indexErrorCount = [];
+  var indexFilePath = [];
+  var indexErrors = [];
 
-  var index = 0,
-      errorCount = 0,
-      config = yaml.safeLoad(yml),
-      settings = _.extend({ columns: true }, config.settings),
-      parser = parse(settings),
-      transformer = transform(testRow);
+  var proc = glob(arg);
+  proc.on('end',function(files){
+    _.each(files, function(file,index) {
+      var filePath = path.resolve(process.cwd(), file);
+      indexCount[index] = 0;
+      indexErrorCount[index] = 0;
+      indexFilePath[index] = filePath;
+      indexErrors[index] = [];
+      parseStream(filePath,yml,index);
+    });
+  });
 
   if (validators && _.isObject(validators)) addValidators(validators);
 
-  stream.pipe(parser).pipe(transformer);
-  stream.on('end', finish);
+  function parseStream(filePath,yml,index) {
+    var stream = fs.createReadStream(filePath, 'utf8');
 
-  function testRow(row) {
-    index++;
-    _.each(row, function(value, field) {
-      var error = testField(value, field, row);
-      if (error) console.error(chalk.red(error));
-    });
-  }
+    var config = yaml.safeLoad(yml),
+        settings = _.extend({ columns: true }, config.settings),
+        parser = parse(settings),
+        transformer = transform(testRow);
 
-  function testField(value, field, row) {
-    var fieldIndex = '✗ [row ' + index + ', field ' + field + '] ',
-        rules = config.fields[field],
-        output = [];
+    stream.pipe(parser).pipe(transformer);
+    stream.on('end', finish);
 
-    rules = _.isString(rules) ? [rules] : rules;
+    function testRow(row) {
+      indexCount[index]++;
 
-    _.each(rules, function(options, rule) {
-      if (_.isArray(rules)) {
-        rule = options;
-        options = undefined;
-      }
+      _.each(row, function(value, field) {
 
-      if (_.isObject(rule)) {
-        options = _.values(rule)[0];
-        rule = _.keys(rule)[0];
-      }
-
-      var args = _.isArray(options) ?
-            [value].concat(options) : [value, options],
-          test = validator[rule];
-
-      if (!test) throw new Error('`' + rule + '` is not a valid rule.');
-
-      this.row = row;
-      this.field = field;
-      this.value = value;
-
-      if (!test.apply(this, args)) {
-        errorCount = errorCount + 1;
-        output.push(fieldIndex + '`' + rule + '` failed.');
-      }
-    });
-
-    return output.join('\n');
-  }
-
-  function finish() {
-    console.log(index + ' rows tested');
-    if (errorCount) {
-      var label = errorCount === 1 ? ' error' : ' errors';
-      console.log(chalk.red(errorCount + label + ' found'));
-      process.exit(1);
-    } else {
-      console.log(chalk.green('no errors found'));
-      process.exit(0);
+        var error = testField(value, field, row, config, index);
+        if (error) console.error(chalk.red(error));
+      });
     }
-  }
 
-  function addValidators(validators) {
-    _.each(validators, function(func, key) {
-      validator.extend(key, func);
-    });
+    function testField(value, field, row, config, index) {
+      var fieldIndex = '✗ [row ' + indexCount[index] + ', field ' + field + '] ',
+          rules = config.fields[field],
+          output = [];
+
+      rules = _.isString(rules) ? [rules] : rules;
+
+      _.each(rules, function(options, rule) {
+        if (_.isArray(rules)) {
+          rule = options;
+          options = undefined;
+        }
+
+        if (_.isObject(rule)) {
+          options = _.values(rule)[0];
+          rule = _.keys(rule)[0];
+        }
+
+        var args = _.isArray(options) ?
+              [value].concat(options) : [value, options],
+            test = validator[rule];
+
+        if (!test) throw new Error('`' + rule + '` is not a valid rule.');
+
+        this.row = row;
+        this.field = field;
+        this.value = value;
+
+        if (!test.apply(this, args)) {
+          indexErrorCount[index]++;
+          indexErrors[index].push(fieldIndex + '`' + rule + '` failed.');
+        }
+      });
+
+    }
+
+    function finish() {
+      console.log("Results for " + indexFilePath[index]);
+      console.log(indexCount[index] + ' rows tested');
+      if (indexErrorCount[index]) {
+        var label = indexErrorCount[index] === 1 ? ' error' : ' errors';
+        _.each(indexErrors[index], function(error) {
+          console.log(chalk.red(error));
+        });
+        console.log(chalk.red(indexErrorCount[index] + label + ' found'));
+        process.exitCode = 1;
+      } else {
+        console.log(chalk.green('no errors found'));
+      }
+    }
+
+    function addValidators(validators) {
+      _.each(validators, function(func, key) {
+        validator.extend(key, func);
+      });
+    }
+
   }
 
 };

--- a/index.js
+++ b/index.js
@@ -100,12 +100,12 @@ module.exports = function(yml, arg, validators) {
       }
     }
 
-    function addValidators(validators) {
-      _.each(validators, function(func, key) {
-        validator.extend(key, func);
-      });
-    }
+  }
 
+  function addValidators(validators) {
+    _.each(validators, function(func, key) {
+      validator.extend(key, func);
+    });
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "csv-parse": "^1.0.0",
     "js-yaml": "^3.3.1",
     "lodash": "^3.10.1",
+    "glob": "^6.0.4",
     "stream-transform": "^0.1.0",
     "validator": "^4.0.5"
   },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -10,6 +10,15 @@ tape('execute CLI script', function(t) {
   });
 });
 
+tape('execute glob-based script', function(t) {
+  var command = 'bin/csv-test test/fixtures/test.yml test/fixtures/*.csv';
+  exec(command, function(error, stdout, stderr) {
+    if (error) console.error(error);
+    t.plan(1);
+    t.assert(!error, 'runs without error');
+  });
+});
+
 tape('allow fields without rules', function(t) {
   var command = 'bin/csv-test test/fixtures/undefinedFields.yml test/fixtures/test.csv';
   exec(command, function(error, stdout, stderr) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -11,7 +11,7 @@ tape('execute CLI script', function(t) {
 });
 
 tape('execute glob-based script', function(t) {
-  var command = 'bin/csv-test test/fixtures/test.yml 'test/fixtures/*.csv';
+  var command = 'bin/csv-test test/fixtures/test.yml "test/fixtures/*.csv"';
   exec(command, function(error, stdout, stderr) {
     if (error) console.error(error);
     t.plan(1);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -11,7 +11,7 @@ tape('execute CLI script', function(t) {
 });
 
 tape('execute glob-based script', function(t) {
-  var command = 'bin/csv-test test/fixtures/test.yml test/fixtures/*.csv';
+  var command = 'bin/csv-test test/fixtures/test.yml 'test/fixtures/*.csv';
   exec(command, function(error, stdout, stderr) {
     if (error) console.error(error);
     t.plan(1);


### PR DESCRIPTION
I followed the recommendation #5 and added https://github.com/isaacs/node-glob .

I wrapped the stream creation in a function and saved the results in arrays so they would be returned together once a stream was closed.  This could have negative performance on a large file if there are many many errors.  I have tested this with a couple of directories but not with any large files.

One thing about this is it requires you to use parentheses.  If you don't the cli interprets the wildcard and gives you all of the files. 

So the args for `bin/csv-test test/fixtures/test.yml test/fixtures/*.csv custom-validator.yml` would give you an array like `['test/fixtures/test.yml',  'test/fixtures/test.csv',  'test/fixtures/customValidators.csv','custom-validator.yml']`. 

While the args for `bin/csv-test test/fixtures/test.yml "test/fixtures/*.csv" custom-validator.yml` would be `['test/fixtures/test.yml',  'test/fixtures/*.csv','custom-validator.yml']` which is the correct args.

So it might be good to check how many args there are.
